### PR TITLE
Add "make install" section for make. Add a .pc file for pkg-config.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,20 @@
 CC := gcc
 
+AR := ar
+ARFLAGS := rs
+
+INSTALL_PREFIX := /usr/local
+INSTALL_LIB := ${INSTALL_PREFIX}/share/liblogger
+INSTALL_SO := /usr/lib
+INSTALL_INC := /usr/include/liblogger
+
 ifeq ($(debug), y)
     CFLAGS := -g
 else
     CFLAGS := -O2 -DNDEBUG
 endif
 
-CFLAGS := $(CFLAGS) -Wall -Werror
+CFLAGS := $(CFLAGS) -Wall -Werror -fPIC
 
 LIBS := -lpthread
 
@@ -16,13 +24,26 @@ TARGET := test_logger
 
 .PHONY: all clean
 
-all: $(OBJS) $(TARGET)
+all: $(OBJS) $(TARGET) liblogger.so.1
 
 $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+
+liblogger.so.1: logger.o
+	$(CC) $(CFLAGS) $^ -shared -o $@
 
 .c.o:
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(TARGET) $(OBJS)
+	rm -f $(TARGET) $(OBJS) liblogger.so.1
+
+install: all
+	@[ -d ${INSTALL_LIB} ] || mkdir ${INSTALL_LIB}
+	@[ -d ${INSTALL_INC} ] || mkdir ${INSTALL_INC}
+	cp ./*.h ${INSTALL_INC}
+	cp ./liblogger.pc /usr/share/pkgconfig
+	cp ./*.so.* ${INSTALL_LIB}
+	ln -s ${INSTALL_LIB}/liblogger.so.* ${INSTALL_SO}/liblogger.so
+	@echo "Finished !"
+	

--- a/liblogger.pc
+++ b/liblogger.pc
@@ -1,0 +1,11 @@
+prefix=/usr/local
+exec_prefix=${prefix}
+includedir=/usr/include/liblogger
+
+Name: liblogger
+Version: 0.1
+Description: A thread-safe logger for C/C++.
+Requires:
+Libs: -llogger -lpthread
+Cflags: -I${includedir}
+


### PR DESCRIPTION
Hi, _ouonline_. Maybe we'd better add a `README.md` and make the library easy to use! I wrote a .pc file for pkg-config tool. Through i've no idea of a suiltable library name. I temporarily called it **liblogger**, depending on the author, whatever! And installing directions shell be adjusted in Makefile. Luck!